### PR TITLE
Enable pagination

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version_coroutines"
 
     // Paging
-    implementation "androidx.paging:paging-runtime:$version_paging"
+    implementation "androidx.paging:paging-runtime-ktx:$version_paging"
 
     // Room database
     implementation "androidx.room:room-runtime:$version_room"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     implementation "androidx.navigation:navigation-fragment-ktx:$version_navigation"
     implementation "androidx.navigation:navigation-ui-ktx:$version_navigation"
 
+    // Paging
+    implementation "androidx.paging:paging-runtime:$version_paging"
+
     // Room database
     implementation "androidx.room:room-runtime:$version_room"
     kapt "androidx.room:room-compiler:$version_room"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,6 +60,10 @@ dependencies {
     implementation "androidx.navigation:navigation-fragment-ktx:$version_navigation"
     implementation "androidx.navigation:navigation-ui-ktx:$version_navigation"
 
+    //Coroutines
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$version_coroutines"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version_coroutines"
+
     // Paging
     implementation "androidx.paging:paging-runtime:$version_paging"
 

--- a/app/src/main/java/com/example/flixt/BindingAdapter.kt
+++ b/app/src/main/java/com/example/flixt/BindingAdapter.kt
@@ -3,18 +3,10 @@ package com.example.flixt
 import android.widget.ImageView
 import androidx.core.net.toUri
 import androidx.databinding.BindingAdapter
-import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.example.flixt.domain.Movie
 import com.example.flixt.network.TmdbApiService.Companion.POSTER_IMAGE_BASE_URL
 import com.example.flixt.network.TmdbApiService.Companion.POSTER_IMAGE_SIZE
-import com.example.flixt.overview.MovieGridAdapter
-
-@BindingAdapter("listData")
-fun bindRecyclerView(recyclerView: RecyclerView, data: List<Movie>?) {
-    val adapter = recyclerView.adapter as MovieGridAdapter
-    adapter.submitList(data)
-}
 
 
 @BindingAdapter("imgUrl")

--- a/app/src/main/java/com/example/flixt/data/database/DatabaseEntities.kt
+++ b/app/src/main/java/com/example/flixt/data/database/DatabaseEntities.kt
@@ -1,4 +1,4 @@
-package com.example.flixt.database
+package com.example.flixt.data.database
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey

--- a/app/src/main/java/com/example/flixt/data/database/DatabaseEntities.kt
+++ b/app/src/main/java/com/example/flixt/data/database/DatabaseEntities.kt
@@ -10,7 +10,7 @@ data class DatabaseMovie constructor(
     val id: Int,
     val title: String,
     val overview: String,
-    val backdropPath: String,
+    val backdropPath: String?,
     val releaseDate: String,
     val video: Boolean,
     val popularity: Double,

--- a/app/src/main/java/com/example/flixt/data/database/DatabaseEntities.kt
+++ b/app/src/main/java/com/example/flixt/data/database/DatabaseEntities.kt
@@ -4,7 +4,7 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.example.flixt.domain.Movie
 
-@Entity
+@Entity(tableName = "movies")
 data class DatabaseMovie constructor(
     @PrimaryKey
     val id: Int,

--- a/app/src/main/java/com/example/flixt/data/database/Room.kt
+++ b/app/src/main/java/com/example/flixt/data/database/Room.kt
@@ -9,6 +9,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import com.example.flixt.util.Constants.DATABASE_NAME
 
 
 @Dao
@@ -21,17 +22,17 @@ interface MovieDao {
 }
 
 @Database(entities = [DatabaseMovie::class], version = 2)
-abstract class MovieDatabase: RoomDatabase() {
+abstract class MovieDatabase : RoomDatabase() {
     abstract val movieDao: MovieDao
 }
 
 private lateinit var INSTANCE: MovieDatabase
 
 fun getDatabase(context: Context): MovieDatabase {
-    if(!::INSTANCE.isInitialized) {
+    if (!::INSTANCE.isInitialized) {
         synchronized(MovieDatabase::class.java) {
             INSTANCE = Room
-                .databaseBuilder(context, MovieDatabase::class.java, "movies")
+                .databaseBuilder(context, MovieDatabase::class.java, DATABASE_NAME)
                 .fallbackToDestructiveMigration()
                 .build()
         }

--- a/app/src/main/java/com/example/flixt/data/database/Room.kt
+++ b/app/src/main/java/com/example/flixt/data/database/Room.kt
@@ -1,4 +1,4 @@
-package com.example.flixt.database
+package com.example.flixt.data.database
 
 import android.content.Context
 import androidx.lifecycle.LiveData

--- a/app/src/main/java/com/example/flixt/data/database/Room.kt
+++ b/app/src/main/java/com/example/flixt/data/database/Room.kt
@@ -13,14 +13,14 @@ import androidx.room.RoomDatabase
 
 @Dao
 interface MovieDao {
-    @Query("SELECT * FROM DatabaseMovie ORDER BY releaseDate DESC")
+    @Query("SELECT * FROM movies ORDER BY releaseDate DESC")
     fun getMovies(): LiveData<List<DatabaseMovie>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertAll(vararg movies: DatabaseMovie)
 }
 
-@Database(entities = [DatabaseMovie::class], version = 1)
+@Database(entities = [DatabaseMovie::class], version = 2)
 abstract class MovieDatabase: RoomDatabase() {
     abstract val movieDao: MovieDao
 }
@@ -32,6 +32,7 @@ fun getDatabase(context: Context): MovieDatabase {
         synchronized(MovieDatabase::class.java) {
             INSTANCE = Room
                 .databaseBuilder(context, MovieDatabase::class.java, "movies")
+                .fallbackToDestructiveMigration()
                 .build()
         }
     }

--- a/app/src/main/java/com/example/flixt/data/paging/MoviePagingSource.kt
+++ b/app/src/main/java/com/example/flixt/data/paging/MoviePagingSource.kt
@@ -3,26 +3,25 @@ package com.example.flixt.data.paging
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.example.flixt.BuildConfig
-import com.example.flixt.domain.Movie
+import com.example.flixt.network.NetworkMovie
 import com.example.flixt.network.TmdbApiService
-import com.example.flixt.network.asDomainModel
 import retrofit2.HttpException
 import java.io.IOException
 
 private const val STARTING_PAGE = 1
 
 class MoviePagingSource(private val service: TmdbApiService) :
-    PagingSource<Int, Movie>() {
-    override fun getRefreshKey(state: PagingState<Int, Movie>): Int {
+    PagingSource<Int, NetworkMovie>() {
+    override fun getRefreshKey(state: PagingState<Int, NetworkMovie>): Int {
         return 1
     }
 
-    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Movie> {
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, NetworkMovie> {
         val position = params.key ?: STARTING_PAGE
 
         return try {
             val response = service.getMovies(BuildConfig.API_KEY, position)
-            val movies = response.movies.asDomainModel()
+            val movies = response.movies
 
             LoadResult.Page(
                 data = movies,

--- a/app/src/main/java/com/example/flixt/data/paging/MoviePagingSource.kt
+++ b/app/src/main/java/com/example/flixt/data/paging/MoviePagingSource.kt
@@ -1,0 +1,42 @@
+package com.example.flixt.data.paging
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.example.flixt.BuildConfig
+import com.example.flixt.domain.Movie
+import com.example.flixt.network.TmdbApiService
+import com.example.flixt.network.asDomainModel
+import java.io.IOException
+import retrofit2.HttpException
+
+private const val STARTING_PAGE = 1
+
+class MoviePagingSource(private val service: TmdbApiService) :
+    PagingSource<Int, Movie>() {
+    override fun getRefreshKey(state: PagingState<Int, Movie>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
+                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
+        }
+    }
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Movie> {
+        val position = params.key ?: STARTING_PAGE
+
+        return try {
+            val response = service.getMovies(BuildConfig.API_KEY, position)
+            val movies = response.movies.asDomainModel()
+            val nextKey = if (response.totalPages <= position) null else position + 1
+
+            LoadResult.Page(
+                data = movies,
+                prevKey = if (position == STARTING_PAGE) null else position - 1,
+                nextKey = nextKey
+            )
+        } catch (exception: IOException) {
+            LoadResult.Error(exception)
+        } catch (exception: HttpException) {
+            LoadResult.Error(exception)
+        }
+    }
+}

--- a/app/src/main/java/com/example/flixt/data/paging/MoviePagingSource.kt
+++ b/app/src/main/java/com/example/flixt/data/paging/MoviePagingSource.kt
@@ -6,18 +6,15 @@ import com.example.flixt.BuildConfig
 import com.example.flixt.domain.Movie
 import com.example.flixt.network.TmdbApiService
 import com.example.flixt.network.asDomainModel
-import java.io.IOException
 import retrofit2.HttpException
+import java.io.IOException
 
 private const val STARTING_PAGE = 1
 
 class MoviePagingSource(private val service: TmdbApiService) :
     PagingSource<Int, Movie>() {
-    override fun getRefreshKey(state: PagingState<Int, Movie>): Int? {
-        return state.anchorPosition?.let { anchorPosition ->
-            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
-                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
-        }
+    override fun getRefreshKey(state: PagingState<Int, Movie>): Int {
+        return 1
     }
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Movie> {
@@ -26,12 +23,11 @@ class MoviePagingSource(private val service: TmdbApiService) :
         return try {
             val response = service.getMovies(BuildConfig.API_KEY, position)
             val movies = response.movies.asDomainModel()
-            val nextKey = if (response.totalPages <= position) null else position + 1
 
             LoadResult.Page(
                 data = movies,
                 prevKey = if (position == STARTING_PAGE) null else position - 1,
-                nextKey = nextKey
+                nextKey = if (response.totalPages <= position) null else position + 1
             )
         } catch (exception: IOException) {
             LoadResult.Error(exception)

--- a/app/src/main/java/com/example/flixt/network/DataTransferObjects.kt
+++ b/app/src/main/java/com/example/flixt/network/DataTransferObjects.kt
@@ -23,7 +23,7 @@ data class NetworkMovie(
     val popularity: Double,
     @Json(name = "poster_path") val posterPath: String,
     @Json(name = "original_title") val originalTitle: String,
-    @Json(name = "backdrop_path") val backdropPath: String,
+    @Json(name = "backdrop_path") val backdropPath: String?,
     val overview: String,
     @Json(name = "release_date") val releaseDate: String,
 ) : Parcelable

--- a/app/src/main/java/com/example/flixt/network/DataTransferObjects.kt
+++ b/app/src/main/java/com/example/flixt/network/DataTransferObjects.kt
@@ -2,6 +2,7 @@ package com.example.flixt.network
 
 import android.os.Parcelable
 import com.example.flixt.data.database.DatabaseMovie
+import com.example.flixt.domain.Movie
 import com.squareup.moshi.Json
 import kotlinx.parcelize.Parcelize
 
@@ -26,6 +27,17 @@ data class NetworkMovie(
     val overview: String,
     @Json(name = "release_date") val releaseDate: String,
 ) : Parcelable
+
+fun List<NetworkMovie>.asDomainModel(): List<Movie> {
+    return map {
+        Movie(
+            id = it.id,
+            title = it.title,
+            posterPath = it.posterPath,
+            overview = it.overview,
+        )
+    }
+}
 
 fun List<NetworkMovie>.asDatabaseModel(): Array<DatabaseMovie> {
     return map {

--- a/app/src/main/java/com/example/flixt/network/DataTransferObjects.kt
+++ b/app/src/main/java/com/example/flixt/network/DataTransferObjects.kt
@@ -1,7 +1,6 @@
 package com.example.flixt.network
 
 import android.os.Parcelable
-import com.example.flixt.data.database.DatabaseMovie
 import com.example.flixt.domain.Movie
 import com.squareup.moshi.Json
 import kotlinx.parcelize.Parcelize
@@ -35,33 +34,4 @@ fun NetworkMovie.asDomainModel(): Movie {
         posterPath = posterPath,
         overview = overview,
     )
-}
-
-fun List<NetworkMovie>.asDomainModel(): List<Movie> {
-    return map {
-        Movie(
-            id = it.id,
-            title = it.title,
-            posterPath = it.posterPath,
-            overview = it.overview,
-        )
-    }
-}
-
-fun List<NetworkMovie>.asDatabaseModel(): Array<DatabaseMovie> {
-    return map {
-        DatabaseMovie(
-            id = it.id,
-            title = it.title,
-            overview = it.overview,
-            backdropPath = it.backdropPath,
-            releaseDate = it.releaseDate,
-            video = it.video,
-            popularity = it.popularity,
-            voteCount = it.voteCount,
-            voteAverage = it.voteAverage,
-            originalTitle = it.originalTitle,
-            posterPath = it.posterPath,
-        )
-    }.toTypedArray()
 }

--- a/app/src/main/java/com/example/flixt/network/DataTransferObjects.kt
+++ b/app/src/main/java/com/example/flixt/network/DataTransferObjects.kt
@@ -6,7 +6,7 @@ import com.squareup.moshi.Json
 import kotlinx.parcelize.Parcelize
 
 data class DiscoverResponse(
-    val results: List<NetworkMovie>,
+    @Json(name = "results") val movies: List<NetworkMovie>,
     val page: Int,
     @Json(name = "total_results") val totalResults: Int,
     @Json(name = "total_pages") val totalPages: Int,

--- a/app/src/main/java/com/example/flixt/network/DataTransferObjects.kt
+++ b/app/src/main/java/com/example/flixt/network/DataTransferObjects.kt
@@ -28,6 +28,15 @@ data class NetworkMovie(
     @Json(name = "release_date") val releaseDate: String,
 ) : Parcelable
 
+fun NetworkMovie.asDomainModel(): Movie {
+    return Movie(
+        id = id,
+        title = title,
+        posterPath = posterPath,
+        overview = overview,
+    )
+}
+
 fun List<NetworkMovie>.asDomainModel(): List<Movie> {
     return map {
         Movie(

--- a/app/src/main/java/com/example/flixt/network/DataTransferObjects.kt
+++ b/app/src/main/java/com/example/flixt/network/DataTransferObjects.kt
@@ -1,7 +1,7 @@
 package com.example.flixt.network
 
 import android.os.Parcelable
-import com.example.flixt.database.DatabaseMovie
+import com.example.flixt.data.database.DatabaseMovie
 import com.squareup.moshi.Json
 import kotlinx.parcelize.Parcelize
 

--- a/app/src/main/java/com/example/flixt/overview/MovieGridAdapter.kt
+++ b/app/src/main/java/com/example/flixt/overview/MovieGridAdapter.kt
@@ -2,13 +2,14 @@ package com.example.flixt.overview
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.example.flixt.databinding.GridListItemBinding
 import com.example.flixt.domain.Movie
 
-class MovieGridAdapter : ListAdapter<Movie, MovieGridAdapter.MoviePosterHolder>(MovieListDiffCallback) {
+class MovieGridAdapter :
+    PagingDataAdapter<Movie, MovieGridAdapter.MoviePosterHolder>(MovieListDiffCallback) {
     class MoviePosterHolder private constructor(private val binding: GridListItemBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
@@ -42,7 +43,7 @@ class MovieGridAdapter : ListAdapter<Movie, MovieGridAdapter.MoviePosterHolder>(
     }
 
     override fun onBindViewHolder(holder: MoviePosterHolder, position: Int) {
-        holder.bind(getItem(position))
+        holder.bind(getItem(position)!!)
     }
 
 }

--- a/app/src/main/java/com/example/flixt/overview/MovieGridAdapter.kt
+++ b/app/src/main/java/com/example/flixt/overview/MovieGridAdapter.kt
@@ -8,6 +8,12 @@ import androidx.recyclerview.widget.RecyclerView
 import com.example.flixt.databinding.GridListItemBinding
 import com.example.flixt.domain.Movie
 
+/**
+ * Adapter for displaying [Movie] [List]. [PagingDataAdapter] presents `PagingData` in a
+ * [RecyclerView]. The adapter can be connected to a `Flow`, a `LiveData`, an RxJava `Flowable`,
+ * an RxJava `Observable`, or even a static list using factory methods. It listens to internal
+ * `PagingData` loading events and efficiently updates the UI as pages are loaded.
+ */
 class MovieGridAdapter :
     PagingDataAdapter<Movie, MovieGridAdapter.MoviePosterHolder>(MovieListDiffCallback) {
     class MoviePosterHolder private constructor(private val binding: GridListItemBinding) :

--- a/app/src/main/java/com/example/flixt/overview/OverviewFragment.kt
+++ b/app/src/main/java/com/example/flixt/overview/OverviewFragment.kt
@@ -8,7 +8,6 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.example.flixt.databinding.FragmentOverviewBinding
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 class OverviewFragment : Fragment() {
@@ -33,8 +32,8 @@ class OverviewFragment : Fragment() {
         binding.lifecycleOwner = viewLifecycleOwner
         binding.overviewViewModel = viewModel
 
-        lifecycleScope.launch {
-            viewModel.movies.collectLatest {
+        viewModel.movies.observe(viewLifecycleOwner) {
+            lifecycleScope.launch {
                 movieGridAdapter.submitData(it)
             }
         }

--- a/app/src/main/java/com/example/flixt/overview/OverviewFragment.kt
+++ b/app/src/main/java/com/example/flixt/overview/OverviewFragment.kt
@@ -14,11 +14,7 @@ import kotlinx.coroutines.launch
 class OverviewFragment : Fragment() {
 
     private val viewModel: OverviewViewModel by lazy {
-        val activity = requireNotNull(this.activity) {
-            "ViewModel cannot be accessed before fragment is created"
-        }
-        val factory = OverviewViewModel.Factory(activity.application)
-        ViewModelProvider(this, factory)[OverviewViewModel::class.java]
+        ViewModelProvider(this)[OverviewViewModel::class.java]
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/example/flixt/overview/OverviewFragment.kt
+++ b/app/src/main/java/com/example/flixt/overview/OverviewFragment.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.example.flixt.databinding.FragmentOverviewBinding
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 class OverviewFragment : Fragment() {
@@ -36,8 +37,8 @@ class OverviewFragment : Fragment() {
         binding.lifecycleOwner = viewLifecycleOwner
         binding.overviewViewModel = viewModel
 
-        viewModel.movies.observe(viewLifecycleOwner) {
-            lifecycleScope.launch {
+        lifecycleScope.launch {
+            viewModel.movies.collectLatest {
                 movieGridAdapter.submitData(it)
             }
         }

--- a/app/src/main/java/com/example/flixt/overview/OverviewFragment.kt
+++ b/app/src/main/java/com/example/flixt/overview/OverviewFragment.kt
@@ -6,7 +6,9 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import com.example.flixt.databinding.FragmentOverviewBinding
+import kotlinx.coroutines.launch
 
 class OverviewFragment : Fragment() {
 
@@ -26,11 +28,19 @@ class OverviewFragment : Fragment() {
 
         val binding = FragmentOverviewBinding.inflate(inflater)
 
-        binding.movieList.adapter = MovieGridAdapter()
+        val movieGridAdapter = MovieGridAdapter()
+
+        binding.movieList.adapter = movieGridAdapter
         binding.movieList.setHasFixedSize(true)
 
         binding.lifecycleOwner = viewLifecycleOwner
         binding.overviewViewModel = viewModel
+
+        viewModel.movies.observe(viewLifecycleOwner) {
+            lifecycleScope.launch {
+                movieGridAdapter.submitData(it)
+            }
+        }
 
         return binding.root
     }

--- a/app/src/main/java/com/example/flixt/overview/OverviewViewModel.kt
+++ b/app/src/main/java/com/example/flixt/overview/OverviewViewModel.kt
@@ -23,7 +23,6 @@ class OverviewViewModel(application: Application) : ViewModel() {
     }
 
     val movies = repository.getMoviesStream().cachedIn(viewModelScope)
-    // TODO: Use flows
 
     class Factory(private val app: Application) : ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: Class<T>): T {

--- a/app/src/main/java/com/example/flixt/overview/OverviewViewModel.kt
+++ b/app/src/main/java/com/example/flixt/overview/OverviewViewModel.kt
@@ -23,7 +23,7 @@ class OverviewViewModel(application: Application): ViewModel() {
 
     val movies = repository.movies
 
-    class Factory(val app: Application): ViewModelProvider.Factory {
+    class Factory(private val app: Application): ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             if (modelClass.isAssignableFrom(OverviewViewModel::class.java)) {
                 @Suppress("UNCHECKED_CAST")

--- a/app/src/main/java/com/example/flixt/overview/OverviewViewModel.kt
+++ b/app/src/main/java/com/example/flixt/overview/OverviewViewModel.kt
@@ -1,37 +1,15 @@
 package com.example.flixt.overview
 
-import android.app.Application
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
-import com.example.flixt.data.database.getDatabase
 import com.example.flixt.network.TmdbApi
 import com.example.flixt.repository.MoviesRepository
-import kotlinx.coroutines.launch
 
-class OverviewViewModel(application: Application) : ViewModel() {
+class OverviewViewModel : ViewModel() {
 
     private val service = TmdbApi.retrofitService
-    private val database = getDatabase(application)
-    private val repository = MoviesRepository(service, database)
-
-    init {
-        viewModelScope.launch {
-            repository.refreshMovies()
-        }
-    }
+    private val repository = MoviesRepository(service)
 
     val movies = repository.getMoviesStream().cachedIn(viewModelScope)
-
-    class Factory(private val app: Application) : ViewModelProvider.Factory {
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            if (modelClass.isAssignableFrom(OverviewViewModel::class.java)) {
-                @Suppress("UNCHECKED_CAST")
-                return OverviewViewModel(app) as T
-            }
-
-            throw IllegalArgumentException("Unable to construct viewmodel")
-        }
-    }
 }

--- a/app/src/main/java/com/example/flixt/overview/OverviewViewModel.kt
+++ b/app/src/main/java/com/example/flixt/overview/OverviewViewModel.kt
@@ -4,12 +4,13 @@ import android.app.Application
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import androidx.paging.cachedIn
 import com.example.flixt.data.database.getDatabase
+import com.example.flixt.network.TmdbApi
 import com.example.flixt.repository.MoviesRepository
 import kotlinx.coroutines.launch
-import com.example.flixt.network.TmdbApi
 
-class OverviewViewModel(application: Application): ViewModel() {
+class OverviewViewModel(application: Application) : ViewModel() {
 
     private val service = TmdbApi.retrofitService
     private val database = getDatabase(application)
@@ -21,9 +22,10 @@ class OverviewViewModel(application: Application): ViewModel() {
         }
     }
 
-    val movies = repository.movies
+    val movies = repository.getMoviesStream().cachedIn(viewModelScope)
+    // TODO: Use flows
 
-    class Factory(private val app: Application): ViewModelProvider.Factory {
+    class Factory(private val app: Application) : ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             if (modelClass.isAssignableFrom(OverviewViewModel::class.java)) {
                 @Suppress("UNCHECKED_CAST")

--- a/app/src/main/java/com/example/flixt/overview/OverviewViewModel.kt
+++ b/app/src/main/java/com/example/flixt/overview/OverviewViewModel.kt
@@ -1,6 +1,7 @@
 package com.example.flixt.overview
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
 import com.example.flixt.network.TmdbApi
@@ -11,5 +12,5 @@ class OverviewViewModel : ViewModel() {
     private val service = TmdbApi.retrofitService
     private val repository = MoviesRepository(service)
 
-    val movies = repository.getMoviesStream().cachedIn(viewModelScope)
+    val movies = repository.getMoviesStream().asLiveData().cachedIn(viewModelScope)
 }

--- a/app/src/main/java/com/example/flixt/overview/OverviewViewModel.kt
+++ b/app/src/main/java/com/example/flixt/overview/OverviewViewModel.kt
@@ -7,11 +7,13 @@ import androidx.lifecycle.viewModelScope
 import com.example.flixt.database.getDatabase
 import com.example.flixt.repository.MoviesRepository
 import kotlinx.coroutines.launch
+import com.example.flixt.network.TmdbApi
 
 class OverviewViewModel(application: Application): ViewModel() {
 
+    private val service = TmdbApi.retrofitService
     private val database = getDatabase(application)
-    private val repository = MoviesRepository(database)
+    private val repository = MoviesRepository(service, database)
 
     init {
         viewModelScope.launch {

--- a/app/src/main/java/com/example/flixt/overview/OverviewViewModel.kt
+++ b/app/src/main/java/com/example/flixt/overview/OverviewViewModel.kt
@@ -12,5 +12,8 @@ class OverviewViewModel : ViewModel() {
     private val service = TmdbApi.retrofitService
     private val repository = MoviesRepository(service)
 
+    // cachedIn allows the paged data to remain active in the viewModel scope
+    // so, even if the UI were to go through lifecycle changes, the paged data would remain in cache
+    // and the UI does not have to start paging from the beginning when it resumes
     val movies = repository.getMoviesStream().asLiveData().cachedIn(viewModelScope)
 }

--- a/app/src/main/java/com/example/flixt/overview/OverviewViewModel.kt
+++ b/app/src/main/java/com/example/flixt/overview/OverviewViewModel.kt
@@ -4,7 +4,7 @@ import android.app.Application
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.example.flixt.database.getDatabase
+import com.example.flixt.data.database.getDatabase
 import com.example.flixt.repository.MoviesRepository
 import kotlinx.coroutines.launch
 import com.example.flixt.network.TmdbApi

--- a/app/src/main/java/com/example/flixt/repository/MoviesRepository.kt
+++ b/app/src/main/java/com/example/flixt/repository/MoviesRepository.kt
@@ -1,14 +1,12 @@
 package com.example.flixt.repository
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.map
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.liveData
 import com.example.flixt.BuildConfig
 import com.example.flixt.data.database.MovieDatabase
-import com.example.flixt.data.database.asDomainModel
 import com.example.flixt.data.paging.MoviePagingSource
 import com.example.flixt.domain.Movie
 import com.example.flixt.network.TmdbApiService
@@ -21,9 +19,7 @@ class MoviesRepository(
     private val database: MovieDatabase
 ) {
 
-    val movies: LiveData<List<Movie>> = database.movieDao.getMovies().map {
-        it.asDomainModel()
-    }
+    // TODO: Use RemoteMediator
 
     suspend fun refreshMovies() {
         withContext(Dispatchers.IO) {
@@ -32,7 +28,7 @@ class MoviesRepository(
         }
     }
 
-    fun getMoviesStream(page: Int): LiveData<PagingData<Movie>> {
+    fun getMoviesStream(): LiveData<PagingData<Movie>> {
         return Pager(
             config = PagingConfig(
                 pageSize = 20,

--- a/app/src/main/java/com/example/flixt/repository/MoviesRepository.kt
+++ b/app/src/main/java/com/example/flixt/repository/MoviesRepository.kt
@@ -3,8 +3,8 @@ package com.example.flixt.repository
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.map
 import com.example.flixt.BuildConfig
-import com.example.flixt.database.MovieDatabase
-import com.example.flixt.database.asDomainModel
+import com.example.flixt.data.database.MovieDatabase
+import com.example.flixt.data.database.asDomainModel
 import com.example.flixt.domain.Movie
 import com.example.flixt.network.TmdbApiService
 import com.example.flixt.network.asDatabaseModel

--- a/app/src/main/java/com/example/flixt/repository/MoviesRepository.kt
+++ b/app/src/main/java/com/example/flixt/repository/MoviesRepository.kt
@@ -2,9 +2,14 @@ package com.example.flixt.repository
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.map
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.liveData
 import com.example.flixt.BuildConfig
 import com.example.flixt.data.database.MovieDatabase
 import com.example.flixt.data.database.asDomainModel
+import com.example.flixt.data.paging.MoviePagingSource
 import com.example.flixt.domain.Movie
 import com.example.flixt.network.TmdbApiService
 import com.example.flixt.network.asDatabaseModel
@@ -25,5 +30,15 @@ class MoviesRepository(
             val response = service.getMovies(BuildConfig.API_KEY, 1)
             database.movieDao.insertAll(*response.movies.asDatabaseModel())
         }
+    }
+
+    fun getMoviesStream(page: Int): LiveData<PagingData<Movie>> {
+        return Pager(
+            config = PagingConfig(
+                pageSize = 20,
+                enablePlaceholders = false
+            ),
+            pagingSourceFactory = { MoviePagingSource(service) }
+        ).liveData
     }
 }

--- a/app/src/main/java/com/example/flixt/repository/MoviesRepository.kt
+++ b/app/src/main/java/com/example/flixt/repository/MoviesRepository.kt
@@ -3,14 +3,17 @@ package com.example.flixt.repository
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
+import androidx.paging.map
 import com.example.flixt.BuildConfig
 import com.example.flixt.data.database.MovieDatabase
 import com.example.flixt.data.paging.MoviePagingSource
 import com.example.flixt.domain.Movie
 import com.example.flixt.network.TmdbApiService
 import com.example.flixt.network.asDatabaseModel
+import com.example.flixt.network.asDomainModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
 class MoviesRepository(
@@ -34,6 +37,10 @@ class MoviesRepository(
                 enablePlaceholders = false
             ),
             pagingSourceFactory = { MoviePagingSource(service) }
-        ).flow
+        )
+            .flow
+            .map { pagingData ->
+                pagingData.map { it.asDomainModel() }
+            }
     }
 }

--- a/app/src/main/java/com/example/flixt/repository/MoviesRepository.kt
+++ b/app/src/main/java/com/example/flixt/repository/MoviesRepository.kt
@@ -18,6 +18,8 @@ class MoviesRepository(
     // TODO: Use RemoteMediator
 
     fun getMoviesStream(): Flow<PagingData<Movie>> {
+        // Pager is the class responsible for producing the PagingData stream.
+        // It depends on the PagingSource to do this.
         return Pager(
             config = PagingConfig(
                 pageSize = 20,

--- a/app/src/main/java/com/example/flixt/repository/MoviesRepository.kt
+++ b/app/src/main/java/com/example/flixt/repository/MoviesRepository.kt
@@ -6,12 +6,15 @@ import com.example.flixt.BuildConfig
 import com.example.flixt.database.MovieDatabase
 import com.example.flixt.database.asDomainModel
 import com.example.flixt.domain.Movie
-import com.example.flixt.network.TmdbApi
+import com.example.flixt.network.TmdbApiService
 import com.example.flixt.network.asDatabaseModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-class MoviesRepository(private val database: MovieDatabase) {
+class MoviesRepository(
+    private val service: TmdbApiService,
+    private val database: MovieDatabase
+) {
 
     val movies: LiveData<List<Movie>> = database.movieDao.getMovies().map {
         it.asDomainModel()
@@ -19,7 +22,7 @@ class MoviesRepository(private val database: MovieDatabase) {
 
     suspend fun refreshMovies() {
         withContext(Dispatchers.IO) {
-            val response = TmdbApi.retrofitService.getMovies(BuildConfig.API_KEY, 1)
+            val response = service.getMovies(BuildConfig.API_KEY, 1)
             database.movieDao.insertAll(*response.movies.asDatabaseModel())
         }
     }

--- a/app/src/main/java/com/example/flixt/repository/MoviesRepository.kt
+++ b/app/src/main/java/com/example/flixt/repository/MoviesRepository.kt
@@ -1,10 +1,8 @@
 package com.example.flixt.repository
 
-import androidx.lifecycle.LiveData
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
-import androidx.paging.liveData
 import com.example.flixt.BuildConfig
 import com.example.flixt.data.database.MovieDatabase
 import com.example.flixt.data.paging.MoviePagingSource
@@ -12,6 +10,7 @@ import com.example.flixt.domain.Movie
 import com.example.flixt.network.TmdbApiService
 import com.example.flixt.network.asDatabaseModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 
 class MoviesRepository(
@@ -28,13 +27,13 @@ class MoviesRepository(
         }
     }
 
-    fun getMoviesStream(): LiveData<PagingData<Movie>> {
+    fun getMoviesStream(): Flow<PagingData<Movie>> {
         return Pager(
             config = PagingConfig(
                 pageSize = 20,
                 enablePlaceholders = false
             ),
             pagingSourceFactory = { MoviePagingSource(service) }
-        ).liveData
+        ).flow
     }
 }

--- a/app/src/main/java/com/example/flixt/repository/MoviesRepository.kt
+++ b/app/src/main/java/com/example/flixt/repository/MoviesRepository.kt
@@ -19,8 +19,8 @@ class MoviesRepository(private val database: MovieDatabase) {
 
     suspend fun refreshMovies() {
         withContext(Dispatchers.IO) {
-            val movies = TmdbApi.retrofitService.getMovies(BuildConfig.API_KEY, 1)
-            database.movieDao.insertAll(*movies.results.asDatabaseModel())
+            val response = TmdbApi.retrofitService.getMovies(BuildConfig.API_KEY, 1)
+            database.movieDao.insertAll(*response.movies.asDatabaseModel())
         }
     }
 }

--- a/app/src/main/java/com/example/flixt/repository/MoviesRepository.kt
+++ b/app/src/main/java/com/example/flixt/repository/MoviesRepository.kt
@@ -4,31 +4,18 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
-import com.example.flixt.BuildConfig
-import com.example.flixt.data.database.MovieDatabase
 import com.example.flixt.data.paging.MoviePagingSource
 import com.example.flixt.domain.Movie
 import com.example.flixt.network.TmdbApiService
-import com.example.flixt.network.asDatabaseModel
 import com.example.flixt.network.asDomainModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.withContext
 
 class MoviesRepository(
-    private val service: TmdbApiService,
-    private val database: MovieDatabase
+    private val service: TmdbApiService
 ) {
 
     // TODO: Use RemoteMediator
-
-    suspend fun refreshMovies() {
-        withContext(Dispatchers.IO) {
-            val response = service.getMovies(BuildConfig.API_KEY, 1)
-            database.movieDao.insertAll(*response.movies.asDatabaseModel())
-        }
-    }
 
     fun getMoviesStream(): Flow<PagingData<Movie>> {
         return Pager(

--- a/app/src/main/java/com/example/flixt/util/Constants.kt
+++ b/app/src/main/java/com/example/flixt/util/Constants.kt
@@ -1,0 +1,5 @@
+package com.example.flixt.util
+
+object Constants {
+    const val DATABASE_NAME = "flixt"
+}

--- a/app/src/main/res/layout/fragment_overview.xml
+++ b/app/src/main/res/layout/fragment_overview.xml
@@ -26,7 +26,6 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:listData="@{overviewViewModel.movies}"
             app:spanCount="2"
             tools:itemCount="17"
             tools:listitem="@layout/grid_list_item" />

--- a/build.gradle
+++ b/build.gradle
@@ -24,4 +24,5 @@ ext {
     version_recyclerview = "1.3.0"
     version_room = "2.5.2"
     version_paging = "3.1.1"
+    version_coroutines = "1.7.1"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,4 +23,5 @@ ext {
     version_retrofit_coroutines_adapter = "0.9.2"
     version_recyclerview = "1.3.0"
     version_room = "2.5.2"
+    version_paging = "3.1.1"
 }


### PR DESCRIPTION
# Description

Please include the following

### Summary

The app now supports pagination, i.e., scrolling through as many pages as provided by the Tmdb API. The initial
goal was to support offline mode by saving the paginated data to a local database. However, it was decided to be 
included at a later date and the changes are available in `feature/pagination` branch.

### Relevant motivation and context

A list of twenty movies alone does not provide a rich user experience. As a user, I would like to presented with a number
of movies to improve discoverability.

### Dependencies

[Paging (version 3)](https://developer.android.com/topic/libraries/architecture/paging/v3-overview)

(Optional) Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Visual inspection. Code testing skipped.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
